### PR TITLE
Deliver example settings.xml & essential updates for older salt versions

### DIFF
--- a/maven/env.sls
+++ b/maven/env.sls
@@ -11,6 +11,24 @@ maven-config:
     - context:
       m2_home: {{ maven.m2_home }}
 
+maven-settings:
+  file.managed:
+    - name: /home/{{ pillar['user'] }}/.m2/settings.xml
+    - source: salt://maven/files/maven-settings.xml
+    - template: jinja
+    - makedirs: True
+    - mode: 644
+    - user: {{ pillar['user'] }}
+{% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
+    - group: users
+{% else %}
+    - group: {{ pillar['user'] }}
+{% endif %}
+    - context:
+      orgdomain: {{ maven.orgdomain }}
+      scmhost: {{ maven.scmhost }}
+      repohost: {{ maven.repohost }}
+
 # Add maven to alternatives system
 maven-home-alt-install:
   alternatives.install:
@@ -25,7 +43,7 @@ maven-home-alt-set:
   - name: maven-home
   - path: {{ maven.maven_real_home }}
   - require:
-    - maven-home-alt-install
+    - alternatives: maven-home-alt-install
 
 maven-alt-install:
   alternatives.install:
@@ -34,11 +52,11 @@ maven-alt-install:
     - path: {{ maven.maven_realcmd }}
     - priority: {{ maven.alt_priority }}
     - require:
-      - maven-home-alt-set
+      - alternatives: maven-home-alt-set
 
 maven-alt-set:
   alternatives.set:
   - name: maven
   - path: {{ maven.maven_realcmd }}
   - require:
-    - maven-alt-install
+    - alternatives: maven-alt-install

--- a/maven/files/maven-settings.xml
+++ b/maven/files/maven-settings.xml
@@ -1,0 +1,66 @@
+<!-- $URL: https://{{ scmhost }}.{{ orgdomain }}/repos/DEV/tools/maven/conf/settings.xml $ -->
+<!-- $Id: settings.xml 17 2008-06-24 15:20:49Z maven@{{ orgdomain }} $  -->
+
+<settings>
+  <mirrors>
+    <mirror>
+      <id>org_snapshot-mirror</id>
+      <mirrorOf>public-snapshots</mirrorOf>
+      <url>http://{{ repohost }}.{{ orgdomain }}/content/groups/public-snapshots</url>
+    </mirror>
+    <mirror>
+      <id>org_your_mirror</id>
+      <mirrorOf>*</mirrorOf>
+      <url>http://{{ repohost }}.{{ orgdomain }}/content/groups/public</url>
+    </mirror>
+  </mirrors>
+
+  <profiles>
+    <profile>
+      <id>nexus</id>
+      <repositories>
+	<repository>
+	  <id>central</id>
+	  <url>http://central</url>
+	  <releases><enabled>true</enabled></releases>
+	  <snapshots><enabled>true</enabled></snapshots>
+	</repository>
+      </repositories>
+      <pluginRepositories>
+	<pluginRepository>
+	  <id>central</id>
+	  <url>http://central</url>
+	  <releases><enabled>true</enabled></releases>
+	  <snapshots><enabled>true</enabled></snapshots>
+	</pluginRepository>
+      </pluginRepositories>
+    </profile>
+    <profile>
+      <id>public-snapshots</id>
+      <repositories>
+	<repository>
+	  <id>public-snapshots</id>
+	  <url>http://public-snapshots</url>
+	  <releases><enabled>false</enabled></releases>
+	  <snapshots><enabled>true</enabled></snapshots>
+	</repository>
+      </repositories>
+      <pluginRepositories>
+	<pluginRepository>
+	  <id>public-snapshots</id>
+	  <url>http://public-snapshots</url>
+	  <releases><enabled>false</enabled></releases>
+	  <snapshots><enabled>true</enabled></snapshots>
+	</pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>nexus</activeProfile>
+  </activeProfiles>
+  
+  <pluginGroups>
+    <pluginGroup>com.example.mojo</pluginGroup>
+  </pluginGroups>
+</settings>

--- a/maven/init.sls
+++ b/maven/init.sls
@@ -36,7 +36,7 @@ maven-unpack-archive:
     - source_hash: {{ maven.source_hash }}
   {%- endif %}
   {% if grains['saltversioninfo'] < [2016, 11, 0] %}
-     - if_missing: {{ maven.maven_realcmd }}
+    - if_missing: {{ maven.maven_realcmd }}
   {% endif %}
     - archive_format: {{ maven.archive_type }} 
     - onchanges:

--- a/maven/init.sls
+++ b/maven/init.sls
@@ -19,7 +19,7 @@ maven-install-dir:
 {{ archive_file }}:
   file.absent:
     - require_in:
-      - maven-download-archive
+      - cmd: maven-download-archive
 
 maven-download-archive:
   cmd.run:
@@ -28,18 +28,19 @@ maven-download-archive:
     - require:
       - file: maven-install-dir
     - require_in:
-      - maven-unpack-archive
+      - archive: maven-unpack-archive
 
 maven-unpack-archive:
   archive.extracted:
     - name: {{ maven.prefix }}
     - source: file://{{ archive_file }}
-    {%- if maven.source_hash %}
+  {% if grains['saltversioninfo'] > [2016, 11, 6] and maven.source_hash %}
     - source_hash: {{ maven.source_hash }}
-    {%- endif %}
+  {%- endif %}
+  {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+     - if_missing: {{ maven.maven_realcmd }}
+  {% endif %}
     - archive_format: {{ maven.archive_type }} 
-    - user: root
-    - group: root
     - onchanges:
       - cmd: maven-download-archive
 
@@ -49,20 +50,20 @@ maven-update-home-symlink:
     - target: {{ maven.maven_real_home }}
     - force: True
     - require:
-      - maven-unpack-archive
+      - archive: maven-unpack-archive
 
 maven-remove-archive:
   file.absent:
     - name: {{ archive_file }}
     - require:
-      - maven-unpack-archive
+      - archive: maven-unpack-archive
 
 {%- if maven.source_hash %}
 maven-remove-archive-hash:
   file.absent:
     - name: {{ archive_file }}.sha256
     - require:
-      - maven-unpack-archive
+      - archive: maven-unpack-archive
 {%- endif %}
 
 {%- endif %}

--- a/maven/init.sls
+++ b/maven/init.sls
@@ -16,19 +16,17 @@ maven-install-dir:
 
 # curl fails (rc=23) if file exists
 # and test -f cannot detect corrupt archive-file.
-{{ archive_file }}:
+maven-remove-prev-archive:
   file.absent:
-    - require_in:
-      - cmd: maven-download-archive
+    - name: {{ archive_file }}
+    - require:
+      - file: maven-install-dir
 
 maven-download-archive:
   cmd.run:
     - name: curl {{ maven.dl_opts }} -o '{{ archive_file }}' '{{ maven.source_url }}'
-    - unless: test -d {{ maven.maven_realcmd }}
     - require:
-      - file: maven-install-dir
-    - require_in:
-      - archive: maven-unpack-archive
+      - file: maven-remove-prev-archive
 
 maven-unpack-archive:
   archive.extracted:

--- a/maven/settings.sls
+++ b/maven/settings.sls
@@ -7,14 +7,24 @@
 {%- set major          = version.split('.') | first %}
 {%- set mirror         = g.get('mirror', p.get('mirror', 'http://www.us.apache.org/dist/maven' )) %}
 
+{%- set default_orgdomain  = 'example.com' %}
+{%- set default_scmhost    = 'scmhost' %}
+{%- set default_repohost   = 'repository' %}
 {%- set default_prefix     = '/usr/lib' %}
-{%- set default_m2_home    = default_prefix + '/apache-maven-' %}
 {%- set default_source_url = mirror + '/maven-' + major + '/' + version + '/binaries/apache-maven-' + version + '-bin.tar.gz' %}
-{%- set default_source_hash = default_source_url + '.sha1' %}
 {%- set default_dl_opts    = ' -s ' %}
 {%- set default_real_home  = default_prefix + '/apache-maven-' + version %}
+{%- set default_m2_home    = default_real_home %}
 {%- set default_symlink    = '/usr/bin/mvn' %}
 {%- set default_realcmd    = maven_home + '/bin/mvn' %}
+
+{% if salt['grains.get']('saltversioninfo') <= [2016, 11, 6] %}
+   ###### hash for maven3.3.9 #####
+   {%- set default_source_hash = "sha1=5b4c117854921b527ab6190615f9435da730ba05" %}
+{% else %}
+   {%- set default_source_hash = default_source_url + '.sha1' %}
+{% endif %}
+
 {%- set default_alt_priority = '30' %}
 {%- set default_archive_type = 'tar' %}
 
@@ -24,6 +34,10 @@
 {%- else %}
   {%- set source_hash      = g.get('source_hash', p.get('source_hash', default_source_hash )) %}
 {%- endif %}
+
+{%- set orgdomain          = g.get('orgdomain', p.get('orgdomain', default_orgdomain )) %}
+{%- set scmhost            = g.get('scmhost', p.get('scmhost', default_scmhost )) %}
+{%- set repohost           = g.get('repohost', p.get('repohost', default_repohost )) %}
 
 {%- set m2_home            = g.get('m2_home', p.get('m2_home', default_m2_home )) %}
 {%- set dl_opts            = g.get('dl_opts', p.get('dl_opts', default_dl_opts)) %}
@@ -40,6 +54,9 @@
                          'source_url'   : source_url,
                          'source_hash'  : source_hash,
                          'prefix'       : prefix,
+                         'orgdomain'    : orgdomain,
+                         'scmhost'      : scmhost,
+                         'repohost'     : repohost,
                          'm2_home'      : m2_home,
                          'dl_opts'      : dl_opts,
                          'archive_type' : archive_type,

--- a/pillar.example
+++ b/pillar.example
@@ -11,4 +11,7 @@ maven:
   symlink: /usr/bin/mvn
   realcmd: /opt/maven/bin/mvn
   alt_priority: 10000
+  orgdomain: example.com
+  scmhost: svn01
+  repohost: repository
 


### PR DESCRIPTION
This PR adds an example maven-setttings.xml file to the formula.  Maven is quite useless without settings.xml file anyway so this is useful starting point for future idea here. The Jinja template example requires end-user to update two variables in settings.sls.  

This PR addresses following issues seen when tested on older Salt version-

1. **Salt 2015.8.8 (Beryllium) generates "Requisite declaration XXXXXXXXXXX in SLS sqlplus is not formed as a single key dictionary"  errors on requires-**

           Solution: Prefix requisite-type to all requires (i.e. - **cmd**: download-maven-archive ).

2. . **Salt generates warnings on Fedora regarding saltstack/salt#39751**

           Solution: Remove "user: root" and "group: root" from archive.extracted state.

3. **Source_hash handling has issues in salt 2016.11.0 and earlier.** 

         Solution: Only check source_hash on newer Salt version as interim measure. Twooster on #salt IRC suggested "{% if grains['saltversioninfo'] <= [2016, 11, 6] %}" to workaround version-check issue on opensuse/salt 2016.3.

4.  **On older Salt version the formula is broken as archive.extracted "name" exists.**

        Solution: Reintroduce "if_missing" parameter to archive.extracted as recommended solution for older Salt.  This fixes formula on old Salt.

5. **Getting "recursive requisite" error on fedora/ubuntu for statename {{ xxxxx }}**

       Solution: Seemingly fixed by renaming state to avoid ID clash-
`-{{ archive_file }}:
 +maven-remove-prev-archive:`

6. **Bug in maven.env state: https://github.com/saltstack-formulas/maven-formula/issues/14**

     Solution: Fixed in this PR

Tested successfuly (no pillars):
- Fedora 25 / Salt 2016.11.3.1.fc25
- Ubunutu 17 / Salt 2017.7.0+ds-1
- Opensuse Leap / Salt 2016.3.4.84.13