### PR TITLE
Incremental improvements: onchanges, add archetype-catalog.xml pillar support

### DIFF
--- a/maven/env.sls
+++ b/maven/env.sls
@@ -29,7 +29,7 @@ maven-settings:
       scmhost: {{ maven.scmhost }}
       repohost: {{ maven.repohost }}
 
-{% if archetypes != 'undefined' %}
+{% if maven.archetypes != 'undefined' %}
 maven-archetypes:
   cmd.run:
     - name: curl {{ maven.dl_opts }} -o /home/{{ pillar['user'] }}/.m2/archetype-catalog.xml '{{ maven.archetypes }}'

--- a/maven/env.sls
+++ b/maven/env.sls
@@ -29,6 +29,14 @@ maven-settings:
       scmhost: {{ maven.scmhost }}
       repohost: {{ maven.repohost }}
 
+{% if archetypes != 'undefined' %}
+maven-archetypes:
+  cmd.run:
+    - name: curl {{ maven.dl_opts }} -o /home/{{ pillar['user'] }}/.m2/archetype-catalog.xml {{ maven.archetypes }}'
+    - require:
+      - file: maven-settings
+{% endif %}
+
 # Add maven to alternatives system
 maven-home-alt-install:
   alternatives.install:

--- a/maven/env.sls
+++ b/maven/env.sls
@@ -44,6 +44,8 @@ maven-home-alt-set:
   - path: {{ maven.maven_real_home }}
   - require:
     - alternatives: maven-home-alt-install
+  - onchanges:
+    - alternatives: maven-home-alt-install
 
 maven-alt-install:
   alternatives.install:
@@ -53,10 +55,15 @@ maven-alt-install:
     - priority: {{ maven.alt_priority }}
     - require:
       - alternatives: maven-home-alt-set
+    - onchanges:
+      - alternatives: maven-home-alt-install
+      - alternatives: maven-home-alt-set
 
 maven-alt-set:
   alternatives.set:
   - name: maven
   - path: {{ maven.maven_realcmd }}
   - require:
+    - alternatives: maven-alt-install
+  - onchanges:
     - alternatives: maven-alt-install

--- a/maven/init.sls
+++ b/maven/init.sls
@@ -36,7 +36,7 @@ maven-unpack-archive:
     - source_hash: {{ maven.source_hash }}
   {%- endif %}
   {% if grains['saltversioninfo'] < [2016, 11, 0] %}
-     - if_missing: {{ maven.maven_realcmd }}
+    - if_missing: {{ maven.maven_realcmd }}
   {% endif %}
     - archive_format: {{ maven.archive_type }} 
     - onchanges:

--- a/maven/init.sls
+++ b/maven/init.sls
@@ -49,19 +49,15 @@ maven-update-home-symlink:
     - force: True
     - require:
       - archive: maven-unpack-archive
+    - onchanges:
+      - archive: maven-unpack-archive
 
 maven-remove-archive:
   file.absent:
-    - name: {{ archive_file }}
+    - names:
+      - {{ archive_file }}
+      - {{ archive_file }}.sha256
     - require:
       - archive: maven-unpack-archive
-
-{%- if maven.source_hash %}
-maven-remove-archive-hash:
-  file.absent:
-    - name: {{ archive_file }}.sha256
-    - require:
-      - archive: maven-unpack-archive
-{%- endif %}
 
 {%- endif %}

--- a/maven/settings.sls
+++ b/maven/settings.sls
@@ -10,6 +10,7 @@
 {%- set default_orgdomain  = 'example.com' %}
 {%- set default_scmhost    = 'scmhost' %}
 {%- set default_repohost   = 'repository' %}
+{%- set default_archetypes = 'undefined' %}
 {%- set default_prefix     = '/usr/lib' %}
 {%- set default_source_url = mirror + '/maven-' + major + '/' + version + '/binaries/apache-maven-' + version + '-bin.tar.gz' %}
 {%- set default_dl_opts    = ' -s ' %}
@@ -38,6 +39,7 @@
 {%- set orgdomain          = g.get('orgdomain', p.get('orgdomain', default_orgdomain )) %}
 {%- set scmhost            = g.get('scmhost', p.get('scmhost', default_scmhost )) %}
 {%- set repohost           = g.get('repohost', p.get('repohost', default_repohost )) %}
+{%- set archetypes         = g.get('archetypes', p.get('archetypes', default_archetypes )) %}
 
 {%- set m2_home            = g.get('m2_home', p.get('m2_home', default_m2_home )) %}
 {%- set dl_opts            = g.get('dl_opts', p.get('dl_opts', default_dl_opts)) %}
@@ -57,6 +59,7 @@
                          'orgdomain'    : orgdomain,
                          'scmhost'      : scmhost,
                          'repohost'     : repohost,
+                         'archetypes'   : archetypes,
                          'm2_home'      : m2_home,
                          'dl_opts'      : dl_opts,
                          'archive_type' : archive_type,

--- a/pillar.example
+++ b/pillar.example
@@ -14,4 +14,5 @@ maven:
   orgdomain: example.com
   scmhost: svn01
   repohost: repository
+  archetypes: http://repository.example.com/content/repositories/releases/archetype-catalog.xml
 


### PR DESCRIPTION
Small incremental improvements:

(1) Currently maven or maven.env state failure triggers dependent states failure unnecessarily.
(2) Both file.absent states in maven state can be consolidated.
(3) Jinja check (-{%- if maven.source_hash %}) is unnecessary in maven state
(4) If maven archetype-catalog url is found in pillar use it.

Fixed these