### PR TITLE
Get group from pillar or id command

### DIFF
--- a/maven/env.sls
+++ b/maven/env.sls
@@ -12,7 +12,7 @@ maven-config:
       m2_home: {{ maven.m2_home }}
 
 ### Primary user environment support ##
-{% if maven.user != 'undefined_user' %}
+{% if maven.user %}
 
 maven-settings:
   file.managed:
@@ -22,17 +22,15 @@ maven-settings:
     - makedirs: True
     - mode: 644
     - user: {{ maven.user }}
-  {% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
-    - group: users
-  {% else %}
-    - group: {{ maven.user }}
-  {% endif %}
+       {% if maven.group and grains.os not in ('MacOS',) %}
+    - group: {{ maven.group }}
+       {% endif %}
     - context:
       orgdomain: {{ maven.orgdomain }}
       scmhost: {{ maven.scmhost }}
       repohost: {{ maven.repohost }}
 
-  {% if maven.archetypes != 'undefined' %}
+  {% if maven.archetypes %}
 maven-archetypes:
   cmd.run:
     - name: curl {{ maven.dl_opts }} -o /home/{{ maven.user }}/.m2/archetype-catalog.xml '{{ maven.archetypes }}'
@@ -43,11 +41,9 @@ maven-archetypes:
     - replace: False
     - mode: 644
     - user: {{ maven.user }}
-     {% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
-    - group: users
-     {% else %}
-    - group: {{ maven.user }}
-     {% endif %}
+       {% if maven.group and grains.os not in ('MacOS',) %}
+    - group: {{ maven.group }}
+       {% endif %}
   {% endif %}
 
 {% endif %}

--- a/maven/settings.sls
+++ b/maven/settings.sls
@@ -7,11 +7,12 @@
 {%- set major              = version.split('.') | first %}
 {%- set mirror             = g.get('mirror', p.get('mirror', 'http://www.us.apache.org/dist/maven' )) %}
 
-{%- set default_user       = 'undefined_user' %}
+{%- set default_user       = None %}
+{%- set default_group      = None %}
 {%- set default_orgdomain  = 'example.com' %}
 {%- set default_scmhost    = 'scmhost' %}
 {%- set default_repohost   = 'repository' %}
-{%- set default_archetypes = 'undefined' %}
+{%- set default_archetypes = None %}
 {%- set default_prefix     = '/usr/lib' %}
 {%- set default_source_url = mirror ~ '/maven-' ~ major ~ '/' ~ version ~ '/binaries/apache-maven-' ~ version ~ '-bin.tar.gz' %}
 {%- set default_dl_opts    = ' -s ' %}
@@ -37,7 +38,13 @@
   {%- set source_hash = g.get('source_hash', p.get('source_hash', default_source_hash )) %}
 {%- endif %}
 
-{%- set user          = g.get('default_user', salt['pillar.get']('default_user', p.get('default_user', default_user)))%}
+# Get user's group name from pillar or 'id' command
+{%- set user  = g.get('default_user', salt['pillar.get']('default_user', p.get('default_user', default_user)))%}
+{%- set group = g.get('default_group', salt['pillar.get']('default_group', p.get('default_group', default_group)))%}
+{%- if not group %}
+  {%- set group = salt['cmd.run']('id -gn', runas=user, output_loglevel='quiet',) or None %}
+{% endif %}
+
 {%- set orgdomain     = g.get('orgdomain', p.get('orgdomain', default_orgdomain )) %}
 {%- set scmhost       = g.get('scmhost', p.get('scmhost', default_scmhost )) %}
 {%- set repohost      = g.get('repohost', p.get('repohost', default_repohost )) %}
@@ -59,6 +66,7 @@
                          'source_hash'  : source_hash,
                          'prefix'       : prefix,
                          'user'         : user,
+                         'group'        : group,
                          'orgdomain'    : orgdomain,
                          'scmhost'      : scmhost,
                          'repohost'     : repohost,

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,7 @@
 maven_home: /opt/maven
-#default_user: undefined_user
+#default_user:
 maven:
-  #default_user: undefined_user
+  #default_user:
   version: 3.3.9
   source_url: http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
   ##source_hash: http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz.sha1
@@ -17,5 +17,5 @@ maven:
   orgdomain: example.com
   scmhost: svn01
   repohost: repository
-  archetypes: http://repository.example.com/content/repositories/releases/archetype-catalog.xml
+  #archetypes: http://repository.example.com/content/repositories/releases/archetype-catalog.xml
 


### PR DESCRIPTION
Get `group` from either `pillar` or GNU coreutils `id -gn` command.   
Fixes failed states when users exist in LDAP and AD.
Verified successfully on Ubuntu 16 with active directory users.
