### PR TITLE
Enable download retries and retry interval

### DIFF
--- a/maven/env.sls
+++ b/maven/env.sls
@@ -38,6 +38,12 @@ maven-archetypes:
     - name: curl {{ maven.dl_opts }} -o /home/{{ maven.user }}/.m2/archetype-catalog.xml '{{ maven.archetypes }}'
     - require:
       - file: maven-settings
+    {% if grains['saltversioninfo'] >= [2017, 7, 0] %}
+    - retry:
+        attempts: {{ maven.dl_retries }}
+        interval: 60
+        splay: 10
+    {% endif %}
   file.managed:
     - name: /home/{{ maven.user }}/.m2/archetype-catalog.xml
     - replace: False

--- a/maven/init.sls
+++ b/maven/init.sls
@@ -27,6 +27,11 @@ maven-download-archive:
     - name: curl {{ maven.dl_opts }} -o '{{ archive_file }}' '{{ maven.source_url }}'
     - require:
       - file: maven-remove-prev-archive
+    {% if grains['saltversioninfo'] >= [2017, 7, 0] %}
+    - retry:
+        attempts: {{ maven.dl_retries }}
+        interval: {{ maven.dl_interval }}
+    {% endif %}
 
 maven-unpack-archive:
   archive.extracted:

--- a/maven/settings.sls
+++ b/maven/settings.sls
@@ -15,6 +15,8 @@
 {%- set default_prefix     = '/usr/lib' %}
 {%- set default_source_url = mirror ~ '/maven-' ~ major ~ '/' ~ version ~ '/binaries/apache-maven-' ~ version ~ '-bin.tar.gz' %}
 {%- set default_dl_opts    = ' -s ' %}
+{%- set default_dl_retries = '1' %}
+{%- set default_dl_interval = '60' %}
 {%- set default_real_home  = default_prefix ~ '/apache-maven-' ~ version %}
 {%- set default_m2_home    = default_real_home %}
 {%- set default_symlink    = '/usr/bin/mvn' %}
@@ -45,6 +47,8 @@
 
 {%- set m2_home       = g.get('m2_home', p.get('m2_home', default_m2_home )) %}
 {%- set dl_opts       = g.get('dl_opts', p.get('dl_opts', default_dl_opts)) %}
+{%- set dl_retries    = g.get('dl_retries', p.get('dl_retries', default_dl_retries)) %}
+{%- set dl_interval   = g.get('dl_interval', p.get('dl_interval', default_dl_interval)) %}
 {%- set prefix        = g.get('prefix', p.get('prefix', default_prefix )) %}
 {%- set real_home     = g.get('real_home', p.get('real_home', default_real_home )) %}
 {%- set symlink       = g.get('symlink', p.get('symlink', default_symlink )) %}
@@ -65,6 +69,8 @@
                          'archetypes'   : archetypes,
                          'm2_home'      : m2_home,
                          'dl_opts'      : dl_opts,
+                         'dl_retries'   : dl_retries,
+                         'dl_interval'  : dl_interval,
                          'archive_type' : archive_type,
                          'real_home'    : real_home,
                          'symlink'      : symlink,

--- a/pillar.example
+++ b/pillar.example
@@ -7,6 +7,7 @@ maven:
   ##source_hash: http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz.sha1
   source_hash: sha1=5b4c117854921b527ab6190615f9435da730ba05
   dl_opts: -s
+  dl_retries: 1
   archive_type: tar
   prefix: /usr/lib
   m2_home: /usr/lib/apache-maven-3.3.9


### PR DESCRIPTION
Retryable actions are supported from Salt 2017.7.0. This PR adds support to this formula, so interrupted downloads can be retried if useful to anyone.

Verified on Ubuntu 16, no regression.
